### PR TITLE
Added splitChunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,5 @@ If you made a useful RStudio addin, feel free to make a pull request [on GitHub]
 | strcode | Insert three levels of code block separators | [strcode](https://github.com/lorenzwalthert/strcode) | :x: | [Lorenz Walthert](http://lorenzwalthert.github.io/) | [Demo GIF](https://raw.githubusercontent.com/lorenzwalthert/strcode/master/man/demo/demo_strcode_v0.1.0.gif) | |
 | datasets.load | Loading datasets from all installed packages | [datasets.load](https://github.com/bquast/datasets.load) | :white_check_mark: | [Bastiaan Quast](http://qua.st/) | [Demo Video](https://www.youtube.com/watch?v=dl_bYlDLydI) | |
 | testthis | Add hotkeys for menial tasks testthat | [testthis](https://bitbucket.org/s_fleck/testthis) | :x: | |  | |
-| typeStringsGadget | Type strings unencumbered | [typeStringsGadget](https://github.com/daranzolin/typeStringsGadget) | :x: | [David Ranzolin](http://daranzolin.github.io) | | |
+| typeStringsGadget | Type strings unencumbered | [typeStringsGadget](https://github.com/daranzolin/typeStringsGadget) | :x: | [David Ranzolin](http://daranzolin.github.io) | | | 
+| splitChunk | Split code chunk in R Markdown | [splitChunk](https://github.com/LudvigOlsen/splitChunk) | :x: | [Ludvig R Olsen](http://ludvigolsen.dk/?lang=en) | | |


### PR DESCRIPTION
I wrote this addin today after wanting it for a looong time.  
It lets you split code chunks in R Markdown.  
I use cmd-alt-i to insert ```{r} ``` - i.e. creating new code chunks. 
This lets you insert ```\n\n```{r} in the middle of a code chunk to split it in two. It also positions the cursor in-between the two chunks, making it easy to add text.
I personally use cmd-alt-shift-i as key command.
